### PR TITLE
Fix: Use user account for commits to count toward contribution streak

### DIFF
--- a/.github/workflows/daily-streak-maintenance.yml
+++ b/.github/workflows/daily-streak-maintenance.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Commit and push changes
         env:
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
+          GIT_AUTHOR_NAME: Numba1ne
+          GIT_AUTHOR_EMAIL: emmanuelanthony357@gmail.com
         run: |
           git config user.name "$GIT_AUTHOR_NAME"
           git config user.email "$GIT_AUTHOR_EMAIL"


### PR DESCRIPTION
## Problem

The current workflow commits as github-actions[bot], which **does not count** toward the user contribution graph on GitHub.

## Changes

Updated .github/workflows/daily-streak-maintenance.yml:
- GIT_AUTHOR_NAME: github-actions[bot] → Numba1ne
- GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com → emmanuelanthony357@gmail.com

## Result

Commits will now be attributed to @Numba1ne and actually appear on your contribution streak graph.

## Privacy Note

Consider switching to your GitHub no-reply email for privacy:
- Go to https://github.com/settings/emails
- Use your private email (e.g., Numba1ne@users.noreply.github.com)

---

Fixes #1